### PR TITLE
Lock screen orientation. Remove tapped listener to prevent app crashes

### DIFF
--- a/TremorTrainer/TremorTrainer.Android/MainActivity.cs
+++ b/TremorTrainer/TremorTrainer.Android/MainActivity.cs
@@ -8,7 +8,7 @@ using Android;
 
 namespace TremorTrainer.Droid
 {
-    [Activity(Label = "TremorTrainer", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize )]
+    [Activity(Label = "TremorTrainer", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Orientation, ScreenOrientation = ScreenOrientation.Portrait)]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
         protected override void OnCreate(Bundle savedInstanceState)

--- a/TremorTrainer/TremorTrainer.iOS/Info.plist
+++ b/TremorTrainer/TremorTrainer.iOS/Info.plist
@@ -10,8 +10,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/TremorTrainer/TremorTrainer/Views/SessionsPage.xaml
+++ b/TremorTrainer/TremorTrainer/Views/SessionsPage.xaml
@@ -30,11 +30,6 @@
                             Style="{DynamicResource ListItemDetailTextStyle}"
                             FontSize="13" />
                         <StackLayout.GestureRecognizers>
-                            <TapGestureRecognizer 
-                                NumberOfTapsRequired="1"
-                                Command="{Binding Source={RelativeSource AncestorType={x:Type local:SessionsViewModel}}, Path=ItemTapped}"		
-                                CommandParameter="{Binding .}">
-                            </TapGestureRecognizer>
                         </StackLayout.GestureRecognizers>
                     </StackLayout>
                 </DataTemplate>


### PR DESCRIPTION
addresses issues #57, #56 